### PR TITLE
Allow node edges weight calc

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ or:
 
 A force-horse element does not have an intrincsic size. It adapts itself to the size that is set by its parent. force-horse is implementing CSS **flex-box** display logic.
 
-# H1 Options parameters
+#  Options parameters
 
 Parameters are passed through the options attribute. Currently, this object contains only the data property, which holds the graph's data in the following format:
 
@@ -26,13 +26,13 @@ Parameters are passed through the options attribute. Currently, this object co
   }
 ```
 
-# H1 API
+# API
 After initializing the directive, force-horse inserts an object into the `options` object sent to it.  This **`forceHorseInstance`** holds inside the force horse API methods. There is one **`forceHorseInstance`** per directive initialized:
 
 **addEventListener** - accepts an event name (String) and a callback (function). For a list of events see **Events** section below.
 
 
-# H1 Events
+# Events
 
 These are the current events. PR's and suggestiong for more are welcome:
 **hover**: a node/link is hovered upon
@@ -43,8 +43,30 @@ These are the current events. PR's and suggestiong for more are welcome:
 
 **filter**: remove the selected nodes/links from the graph
 
-# H1 External Config file
-force-horse supports an external json file, **forceHorse.json**. In this file one can set whether each of the buttons (see below) is displayed or not. Also, force layout parameters can be set, and thus to override the parameters that force-horse computes automatically, for a specific implementation.
+# External Config file
+force-horse supports an external json file, **forceHorse.json**. In this file one can set whether each of the buttons (see below) is displayed or not. 
+Also, force layout parameters can be set, and thus to override the parameters that force-horse computes automatically, for a specific implementation.
+
+The config parameters are:
+```
+{
+  "showLabels": false, //show labels on start
+  "showNodeWeight": false, // show each node weight or uniform size
+  "showEdgeWeight": false, // show each edge weight or uniform size
+  "showFilterButton": true, // show the filter toggle button
+  "showLabelsButton": true, // show the labels toggle button
+  "showNodeWeightButton": true,  // show the nodes weights toggle button
+  "showEdgeWeightButton": true, // show the edges weights toggle button
+  "useEdgesWeights": false, //weather to use edges weights or simple edge sum for node weights
+  "forceParameters": {
+    "charge": -350,
+    "linkStrength": 1,
+    "gravity": 0.2,
+    "linkDistance": 10,
+    "friction": 0.5
+  }
+}
+```
 
 The forceHorse project contains a complete **demo application**. The demo application is also available on the [plunker](http://embed.plnkr.co/SYmehtaAnQVyMpLJJY2B/?show=preview) site.
 

--- a/components/forceHorse/forceHorse.js
+++ b/components/forceHorse/forceHorse.js
@@ -114,7 +114,7 @@ angular.module('forceHorse', [])
             this.element = element[0];
             this.options = options;
             // Set a variable to hold references to registered event listeners
-            this.eventListeners = {f};
+            this.eventListeners = {};
         }
 
         var proto = ForceHorseFactory.prototype;

--- a/components/forceHorse/forceHorse.js
+++ b/components/forceHorse/forceHorse.js
@@ -196,6 +196,7 @@ angular.module('forceHorse', [])
                 showLabelsButton: true,
                 showNodeWeightButton: true,
                 showEdgeWeightButton: true,
+                useEdgesWeights: false,
                 forceParameters: {
                     //charge: -350,
                     linkStrength: 1,
@@ -434,7 +435,7 @@ angular.module('forceHorse', [])
         proto.getNodeIconArea = function (nodeData) {
             var myInstance = this;
             return myInstance.nodeIconAreaDefault
-                + (myInstance.config.showNodeWeight ? nodeData.weight * constants.node_size_addition_per_weight_unit : 0);
+                + (myInstance.config.showNodeWeight ? (myInstance.config.useEdgesWeights?nodeData.edgesWeight:nodeData.weight) * constants.node_size_addition_per_weight_unit : 0);
         };
 
         /**
@@ -559,9 +560,26 @@ angular.module('forceHorse', [])
          * @returns {ForceHorseFactory} current instance
          */
         proto.processEdges = function () {
+            function calculateEdgesWeightsForNodes(edge){
+                // calculate edges weights
+                edge.source.edgesWeights?edge.source.edgesWeights = edge.weight:edge.source.edgesWeights += edge.weight;
+                edge.target.edgesWeights?edge.target.edgesWeights = edge.weight:edge.target.edgesWeights += edge.weight;
+
+                // protect in case undefined
+                if (!edge.source.edgesWeights){
+                    edge.source.edgesWeights = 0;
+                }
+
+                if (!edge.target.edgesWeights){
+                    edge.source.edgesWeights = 0;
+                }
+            }
+
             var myInstance = this, sid, tid, key;
             this.edgesFromNodes = {};
             this.edgeDataArray.forEach(function (val, idx) {
+
+                calculateEdgesWeightsForNodes(val);
                 if (angular.isUndefined(val.id)) {
                     val.id = idx;
                     // console.warn(`Undefined [id] in edge ${val.sourceID} - ${val.targetID}`);

--- a/components/forceHorse/forceHorse.js
+++ b/components/forceHorse/forceHorse.js
@@ -114,7 +114,7 @@ angular.module('forceHorse', [])
             this.element = element[0];
             this.options = options;
             // Set a variable to hold references to registered event listeners
-            this.eventListeners = {hover: [], select: [], filter: [], dblclick: []};
+            this.eventListeners = {f};
         }
 
         var proto = ForceHorseFactory.prototype;
@@ -1186,6 +1186,9 @@ angular.module('forceHorse', [])
          * @returns {ForceHorseFactory} current instance
          */
         proto.addEventListener = function (type, callback) {
+            if (typeof this.eventListeners[type] === 'undefined'){
+                this.eventListeners[type] = [];
+            }
             this.eventListeners[type].push(callback);
             return this;
         };
@@ -1200,6 +1203,9 @@ angular.module('forceHorse', [])
          * @returns {ForceHorseFactory} current instance
          */
         proto.callEventListeners = function (type, ...args) {
+            if (typeof this.eventListeners[type] === 'undefined'){
+                return;
+            }
             this.eventListeners[type].forEach(function (callback) {
                 callback(...args);
             });
@@ -1215,7 +1221,7 @@ angular.module('forceHorse', [])
              * @returns {*|*[]}
              */
         proto.convertFileDataFormat = function (fileData) {
-            return helper.convertFileDataFormat(fileData);  
+            return helper.convertFileDataFormat(fileData);
         };
 
         //---------------------------------------------------

--- a/components/forceHorse/forceHorse_test.js
+++ b/components/forceHorse/forceHorse_test.js
@@ -131,5 +131,14 @@ describe('forceHorse module', function () {
             });
         });
 
+        describe('addEventListener()', function(){
+            it('Should add an event listener', function(){
+                var eventName = 'someEvent';
+
+                aflInstance.addEventListener(eventName, angular.noop);
+                expect(afInstance.eventListeners.eventName.length).toEqual(1);
+            })
+        })
+
     });
 });

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -8,6 +8,7 @@ module.exports = function (config) {
             'bower_components/angular-ui-router/release/angular-ui-router.min.js',
             'bower_components/angular-mocks/angular-mocks.js',
             'bower_components/d3/d3.js',
+            'components/**/*.js',
             'demo-app/app/**/*.js'
         ],
 


### PR DESCRIPTION
use the `useEdgesWeights` in the config in order to use edges weights for node weights calculations instead of the sum of weights calculated in d3 layout.
